### PR TITLE
3-feat: Add initial persona configuration and knowledge file upload fun…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,12 +132,12 @@ export default function HomePage() {
         <div className="flex justify-between items-center mb-12">
           <h1 className="text-4xl font-bold">Logeach</h1>
           <div className="flex items-center gap-4">
-            <span className="text-sm text-muted-foreground">
+            <span className="text-sm text-muted-foreground hidden sm:inline">
               {user.displayName ?? user.email}
             </span>
             <button
               onClick={() => signOut()}
-              className="text-sm px-4 py-1.5 rounded-lg border border-border hover:bg-muted transition-colors"
+              className="text-sm px-4 py-2 text-muted-foreground hover:bg-muted rounded transition-colors"
             >
               ログアウト
             </button>

--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -8,11 +8,12 @@
  * 左下: AIに反論（入力フォーム）      右下: 設定ボタン
  */
 
-import { use } from "react";
+import { use, useState } from "react";
 import Link from "next/link";
 import SlideViewer from "@/src/components/practice/SlideViewer";
 import ChatInterface from "@/src/components/practice/ChatInterface";
 import PersonaConfig from "@/src/components/setup/PersonaConfig";
+import KnowledgeUpload from "@/src/components/setup/KnowledgeUpload";
 
 export default function PracticePage({
     params,
@@ -20,6 +21,8 @@ export default function PracticePage({
     params: Promise<{ id: string }>;
 }) {
     const { id } = use(params);
+    const [isPersonaModalOpen, setIsPersonaModalOpen] = useState(false);
+    const [isKnowledgeModalOpen, setIsKnowledgeModalOpen] = useState(false);
 
     return (
         <div className="h-screen flex flex-col">
@@ -52,11 +55,82 @@ export default function PracticePage({
                         {/* TODO: メンバー2 - AIのコメント表示エリア */}
                         <p className="text-foreground-muted text-sm">AIのコメントがここに表示されます</p>
                     </div>
-                    <div className="border-t border-border p-4">
-                        <PersonaConfig />
+                    <div className="border-t border-border p-4 space-y-3">
+                        <button
+                            onClick={() => setIsPersonaModalOpen(true)}
+                            className="w-full bg-secondary text-secondary-foreground hover:bg-secondary/80 rounded-lg px-4 py-2 text-sm font-medium transition-colors border border-border"
+                        >
+                            AIの人物像をカスタマイズ
+                        </button>
+                        <button
+                            onClick={() => setIsKnowledgeModalOpen(true)}
+                            className="w-full bg-secondary text-secondary-foreground hover:bg-secondary/80 rounded-lg px-4 py-2 text-sm font-medium transition-colors border border-border"
+                        >
+                            前提知識をアップロード
+                        </button>
                     </div>
                 </div>
             </div>
+
+            {/* 人物像設定モーダル */}
+            {isPersonaModalOpen && (
+                <div 
+                    className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
+                    onClick={() => setIsPersonaModalOpen(false)}
+                >
+                    <div 
+                        className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <h2 className="text-xl font-bold mb-4">AIの人物像設定</h2>
+
+                        <PersonaConfig 
+                            sessionId={id}
+                            onSaveSuccess={() => setIsPersonaModalOpen(false)} 
+                        />
+
+                        <div className="mt-6 flex justify-end gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setIsPersonaModalOpen(false)}
+                                className="px-4 py-2 rounded-lg text-sm font-medium hover:bg-muted"
+                            >
+                                閉じる
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* 前提知識アップロードモーダル */}
+            {isKnowledgeModalOpen && (
+                <div 
+                    className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
+                    onClick={() => setIsKnowledgeModalOpen(false)}
+                >
+                    <div 
+                        className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <h2 className="text-xl font-bold mb-4">前提知識のアップロード</h2>
+
+                        <KnowledgeUpload 
+                            sessionId={id}
+                            onSaveSuccess={() => setIsKnowledgeModalOpen(false)} 
+                        />
+
+                        <div className="mt-6 flex justify-end gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setIsKnowledgeModalOpen(false)}
+                                className="px-4 py-2 rounded-lg text-sm font-medium hover:bg-muted"
+                            >
+                                閉じる
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/setup/KnowledgeUpload.tsx
+++ b/src/components/setup/KnowledgeUpload.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { supabase } from "@/src/lib/supabase";
+import { useAuth } from "@/src/components/auth/AuthProvider";
+
+/**
+ * KnowledgeUpload コンポーネント
+ * AIの前提知識（ファイル）のアップロードを専用に行う
+ */
+export default function KnowledgeUpload({ 
+    sessionId,
+    onSaveSuccess 
+}: { 
+    sessionId: string;
+    onSaveSuccess?: () => void 
+}) {
+    const { user } = useAuth();
+    const [files, setFiles] = useState<File[]>([]);
+    const [existingFiles, setExistingFiles] = useState<string[]>([]);
+    const [isUploading, setIsUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // 初期化時に既存のデータを取得する
+    useEffect(() => {
+        const fetchExistingKnowledge = async () => {
+            if (!user || !sessionId) return;
+            
+            // 1. セッション情報を取得して persona_id を確認
+            const { data: sessionData, error: sessionError } = await supabase
+                .from("sessions")
+                .select("persona_id")
+                .eq("id", sessionId)
+                .single();
+
+            if (sessionError || !sessionData?.persona_id) return;
+
+            // 2. persona_id に紐づく人物像の前提知識を取得
+            const { data, error } = await supabase
+                .from("personas")
+                .select("knowledge_files")
+                .eq("id", sessionData.persona_id)
+                .single();
+
+            if (data && !error && data.knowledge_files) {
+                setExistingFiles(data.knowledge_files);
+            }
+        };
+        fetchExistingKnowledge();
+    }, [user, sessionId]);
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files) {
+            const newFiles = Array.from(e.target.files);
+            setFiles(prev => [...prev, ...newFiles]);
+        }
+        if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+        }
+    };
+
+    const removeFile = (indexToRemove: number) => {
+        setFiles(prev => prev.filter((_, index) => index !== indexToRemove));
+    };
+
+    const handleUpload = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!user || files.length === 0) return;
+
+        setIsUploading(true);
+        try {
+            const uploadedFilePaths: string[] = [];
+            
+            for (const file of files) {
+                // ユーザーの要望により、ファイル名をランダムな英数字に変更して保存する（Invalid keyエラー回避のため）
+                const fileExt = file.name.split('.').pop() || '';
+                const safeFileName = `${Math.random().toString(36).substring(2, 15)}.${fileExt}`;
+                const filePath = `${user.id}/${Date.now()}_${safeFileName}`;
+                
+                const { data: storageData, error: storageError } = await supabase.storage
+                    .from('personas-knowledge')
+                    .upload(filePath, file);
+                    
+                if (storageError) {
+                    throw new Error(`ファイル「${file.name}」のアップロードに失敗しました: ${storageError.message}`);
+                }
+                
+                if (storageData) {
+                    uploadedFilePaths.push(storageData.path);
+                }
+            }
+
+            // 1. まず現在のセッションに紐付いている persona_id を取得
+            const { data: sessionData, error: sessionFetchError } = await supabase
+                .from("sessions")
+                .select("persona_id")
+                .eq("id", sessionId)
+                .single();
+
+            if (sessionFetchError) throw sessionFetchError;
+
+            const existingPersonaId = sessionData?.persona_id;
+
+            if (existingPersonaId) {
+                // 既存の人物像の前提知識のみを更新
+                const { error: personaUpdateError } = await supabase
+                    .from("personas")
+                    .update({
+                        knowledge_files: uploadedFilePaths
+                    })
+                    .eq("id", existingPersonaId);
+
+                if (personaUpdateError) throw personaUpdateError;
+            } else {
+                // 新規作成
+                const { data: newPersonaData, error: personaInsertError } = await supabase
+                    .from("personas")
+                    .insert([
+                        {
+                            user_id: user.id,
+                            name: "前提知識", // 名前必須カラムのため固定値を入れる
+                            knowledge_files: uploadedFilePaths
+                        }
+                    ])
+                    .select()
+                    .single();
+
+                if (personaInsertError) throw personaInsertError;
+
+                // セッションと新規人物像を紐付ける
+                if (newPersonaData) {
+                    const { error: sessionUpdateError } = await supabase
+                        .from("sessions")
+                        .update({ persona_id: newPersonaData.id })
+                        .eq("id", sessionId);
+
+                    if (sessionUpdateError) throw sessionUpdateError;
+                }
+            }
+
+            alert("前提知識をアップロードしました！");
+            
+            // 成功時のコールバックを呼ぶ（モーダルを閉じるなど）
+            if (onSaveSuccess) onSaveSuccess();
+            
+            // 既存ファイルリストを更新（擬似的に追加）
+            setExistingFiles(prev => [...prev, ...uploadedFilePaths]);
+            // フォーム（新規選択分）をリセット
+            setFiles([]);
+        } catch (error: any) {
+            console.error("アップロードエラー:", error);
+            alert(`アップロードに失敗しました: ${error.message || "不明なエラー"}`);
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <form onSubmit={handleUpload} className="space-y-4">
+                <div className="pt-2">
+                    <input
+                        type="file"
+                        multiple
+                        ref={fileInputRef}
+                        onChange={handleFileChange}
+                        className="hidden"
+                    />
+                    
+                    <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="w-full border border-border rounded-lg px-4 py-3 text-sm text-left hover:bg-muted font-medium transition-colors flex items-center justify-between"
+                    >
+                        <span>ファイルを選択（複数選択可）</span>
+                        <span className="text-muted-foreground">+</span>
+                    </button>
+
+                    {/* 選択されたファイルのリスト表示 */}
+                    {files.length > 0 && (
+                        <div className="mt-3 space-y-2">
+                            <p className="text-xs font-semibold text-muted-foreground">追加されたファイル</p>
+                            <ul className="space-y-1">
+                                {files.map((file, index) => (
+                                    <li key={index} className="flex items-center justify-between text-sm bg-muted/50 px-3 py-2 rounded">
+                                        <span className="truncate mr-2">{file.name}</span>
+                                        <button
+                                            type="button"
+                                            onClick={() => removeFile(index)}
+                                            className="text-red-500 hover:text-red-700 font-bold px-2"
+                                            aria-label="削除"
+                                        >
+                                            ×
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {/* すでにアップロード済みのファイルのリスト表示 */}
+                    {existingFiles.length > 0 && (
+                        <div className="mt-4 space-y-2">
+                            <p className="text-xs font-semibold text-muted-foreground">アップロード済みのファイル</p>
+                            <ul className="space-y-1">
+                                {existingFiles.map((path, index) => {
+                                    // パスからファイル名を抽出（タイムスタンプ以降の部分）
+                                    const fileName = path.split('_').slice(1).join('_') || path;
+                                    const decodedName = decodeURIComponent(fileName);
+                                    
+                                    return (
+                                        <li key={index} className="flex items-center text-sm bg-blue-50/50 px-3 py-2 rounded text-blue-700 border border-blue-100">
+                                            <span className="truncate">{decodedName}</span>
+                                            <span className="ml-auto text-[10px] bg-blue-100 px-1.5 py-0.5 rounded leading-none">保存済み</span>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={isUploading || files.length === 0}
+                    className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                >
+                    {isUploading ? "アップロード中..." : "アップロードして保存"}
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/src/components/setup/PersonaConfig.tsx
+++ b/src/components/setup/PersonaConfig.tsx
@@ -1,19 +1,182 @@
 "use client";
 
+import { useState, useEffect } from "react";
+import { supabase } from "@/src/lib/supabase";
+import { useAuth } from "@/src/components/auth/AuthProvider";
+
 /**
  * PersonaConfig コンポーネント
- * TODO: メンバー3 - AIの人物像カスタマイズUIと前提知識アップロードを実装
+ * AIの人物像カスタマイズUIと前提知識アップロードを実装
  */
+export default function PersonaConfig({ 
+    sessionId,
+    onSaveSuccess 
+}: { 
+    sessionId: string;
+    onSaveSuccess?: () => void 
+}) {
+    const { user } = useAuth();
+    const [name, setName] = useState("");
+    const [personality, setPersonality] = useState("");
+    const [landmines, setLandmines] = useState("");
+    const [background, setBackground] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
 
-export default function PersonaConfig() {
+    // 初期化時に既存のデータを取得する
+    useEffect(() => {
+        const fetchPersona = async () => {
+            if (!user || !sessionId) return;
+            
+            // 1. セッション情報を取得して persona_id を確認
+            const { data: sessionData, error: sessionError } = await supabase
+                .from("sessions")
+                .select("persona_id")
+                .eq("id", sessionId)
+                .single();
+
+            if (sessionError || !sessionData?.persona_id) return;
+
+            // 2. persona_id に紐づく人物像を取得
+            const { data, error } = await supabase
+                .from("personas")
+                .select("*")
+                .eq("id", sessionData.persona_id)
+                .single();
+
+            if (data && !error) {
+                setName(data.name || "");
+                setBackground(data.background || "");
+                // traits配列から性格と地雷ポイントを抽出
+                const traits = data.traits || [];
+                const personalityTrait = traits.find((t: string) => t.startsWith("性格: "));
+                const landminesTrait = traits.find((t: string) => t.startsWith("地雷ポイント: "));
+                
+                if (personalityTrait) setPersonality(personalityTrait.replace("性格: ", ""));
+                if (landminesTrait) setLandmines(landminesTrait.replace("地雷ポイント: ", ""));
+            }
+        };
+        fetchPersona();
+    }, [user, sessionId]);
+
+    const handleSave = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!user || !name.trim()) return;
+
+        setIsSaving(true);
+        try {
+            // 1. まず現在のセッションに紐付いている persona_id を取得
+            const { data: sessionData, error: sessionFetchError } = await supabase
+                .from("sessions")
+                .select("persona_id")
+                .eq("id", sessionId)
+                .single();
+
+            if (sessionFetchError) throw sessionFetchError;
+
+            const existingPersonaId = sessionData?.persona_id;
+            const personaDataToSave = {
+                user_id: user.id,
+                name: name.trim(),
+                traits: [
+                    personality.trim() ? `性格: ${personality.trim()}` : "",
+                    landmines.trim() ? `地雷ポイント: ${landmines.trim()}` : ""
+                ].filter(Boolean),
+                background: background.trim()
+            };
+
+            if (existingPersonaId) {
+                // 既存の人物像を更新
+                const { error: personaUpdateError } = await supabase
+                    .from("personas")
+                    .update(personaDataToSave)
+                    .eq("id", existingPersonaId);
+
+                if (personaUpdateError) throw personaUpdateError;
+            } else {
+                // 新規作成
+                const { data: newPersonaData, error: personaInsertError } = await supabase
+                    .from("personas")
+                    .insert([personaDataToSave])
+                    .select()
+                    .single();
+
+                if (personaInsertError) throw personaInsertError;
+
+                // セッションと新規人物像を紐付ける
+                if (newPersonaData) {
+                    const { error: sessionUpdateError } = await supabase
+                        .from("sessions")
+                        .update({ persona_id: newPersonaData.id })
+                        .eq("id", sessionId);
+
+                    if (sessionUpdateError) throw sessionUpdateError;
+                }
+            }
+
+            alert("人物像を保存しました！");
+            
+            // 成功時のコールバックを呼ぶ（モーダルを閉じるなど）
+            if (onSaveSuccess) onSaveSuccess();
+            
+            // 以前はここでステートをリセットしていましたが、
+            // 「設定を残したい」という要望に合わせてリセット処理を削除しました。
+        } catch (error: any) {
+            console.error("保存エラー:", error);
+            alert(`保存に失敗しました: ${error.message || "不明なエラー"}`);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
     return (
-        <div className="space-y-3">
-            <button className="w-full border border-border rounded px-4 py-3 text-sm text-left hover:bg-surface-hover">
-                AIの人物像カスタマイズ
-            </button>
-            <button className="w-full border border-border rounded px-4 py-3 text-sm text-left hover:bg-surface-hover">
-                フォルダを選択（前提知識をアップロード）
-            </button>
+        <div className="space-y-6">
+            <form onSubmit={handleSave} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">名前</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder="例: 高橋 健太（面接官）"
+                        className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">性格</label>
+                    <textarea
+                        value={personality}
+                        onChange={(e) => setPersonality(e.target.value)}
+                        placeholder="例: 穏やかだが、論理の飛躍には厳しい。時折鋭い質問を投げる。"
+                        className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm min-h-[80px]"
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">地雷ポイント</label>
+                    <textarea
+                        value={landmines}
+                        onChange={(e) => setLandmines(e.target.value)}
+                        placeholder="例: 抽象的な回答を嫌う。数字を混ぜて話さないと深堀してくる。"
+                        className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm min-h-[80px]"
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">背景（専門分野など）</label>
+                    <textarea
+                        value={background}
+                        onChange={(e) => setBackground(e.target.value)}
+                        placeholder="例: ソフトウェアエンジニアリング専門の面接官"
+                        className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm min-h-[80px]"
+                    />
+                </div>
+                <button
+                    type="submit"
+                    disabled={isSaving || !name.trim()}
+                    className="w-full bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                >
+                    {isSaving ? "保存中..." : "保存する"}
+                </button>
+            </form>
         </div>
     );
 }


### PR DESCRIPTION
1. 人物像設定と前提知識アップロード
・人物設定と前提知識をアップロードの機能を追加しました。
・人物設定では「名前」「性格」「地雷ポイント」「背景」を設定できるようにしました。
・前提知識をアップロードではpdfファイルをSupabaseにアップロードできるようにしました。

2. セッションごとの個別設定（独立管理）
・練習単位の永続化: 各練習セッション（URLのID）ごとに異なる人物像や前提知識を持てるように変更しました。
・データの復元: 過去の練習セッションを一覧から開き直した際、そのセッションで設定した内容やアップロード済みのファイルリストが自動的に読み込まれ、画面に反映されます。

3. 操作性と安定性の向上
・上書きバグの修正: 「人物像を保存するとファイルが消える」「ファイルを上げると人物像が消える」という問題を解消しました。既存の設定がある場合は、新しい部分だけを賢く更新するようにロジックを修正しています。
・自動クローズ機能: 保存やアップロードが完了した際、手動で閉じなくても自動でモーダルが閉じるようにし、スムーズに練習に戻れるようにしました。
・ファイル名のランダム化: ストレージ保存時のエラー（不正な文字など）を回避するため、ファイル名をランダムな英数字に変更して保存する仕様に統一しました。ここは日本語でも対応できるようにする改善点も残ったままです。

・設定画面以外の部分をクリックした際に設定画面が閉じるようにしました。