### PR TITLE
Issue#1 スライド表示エリアの実装

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -10,7 +10,11 @@
 
 import { use } from "react";
 import Link from "next/link";
-import SlideViewer from "@/src/components/practice/SlideViewer";
+import dynamic from "next/dynamic";
+const SlideViewer = dynamic(
+    () => import("@/src/components/practice/SlideViewer"),
+    { ssr: false }
+);
 import ChatInterface from "@/src/components/practice/ChatInterface";
 import PersonaConfig from "@/src/components/setup/PersonaConfig";
 
@@ -38,7 +42,7 @@ export default function PracticePage({
                 <div className="flex-1 flex flex-col border-r border-border">
                     {/* 左上: スライド */}
                     <div className="flex-1 border-b border-border">
-                        <SlideViewer />
+                        <SlideViewer sessionId={id} />
                     </div>
                     {/* 左下: AIに反論 */}
                     <div className="p-4 bg-white">

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-pdf": "^10.4.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1081,6 +1082,256 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.96.tgz",
+      "integrity": "sha512-6NNmNxvoJKeucVjxaaRUt3La2i5jShgiAbaY3G/72s1Vp3U06XPrAIxkAjBxpDcamEn/t+WJ4OOlGmvILo4/Ew==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.96",
+        "@napi-rs/canvas-darwin-arm64": "0.1.96",
+        "@napi-rs/canvas-darwin-x64": "0.1.96",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.96",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.96",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.96",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.96",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.96"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.96.tgz",
+      "integrity": "sha512-ew1sPrN3dGdZ3L4FoohPfnjq0f9/Jk7o+wP7HkQZokcXgIUD6FIyICEWGhMYzv53j63wUcPvZeAwgewX58/egg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.96.tgz",
+      "integrity": "sha512-Q/wOXZ5PzTqpdmA5eUOcegCf4Go/zz3aZ5DlzSeDpOjFmfwMKh8EzLAoweQ+mJVagcHQyzoJhaTEnrO68TNyNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.96.tgz",
+      "integrity": "sha512-UrXiQz28tQEvGM1qvyptewOAfmUrrd5+wvi6Rzjj2VprZI8iZ2KIvBD2lTTG1bVF95AbeDeG7PJA0D9sLKaOFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.96.tgz",
+      "integrity": "sha512-I90ODxweD8aEP6XKU/NU+biso95MwCtQ2F46dUvhec1HesFi0tq/tAJkYic/1aBSiO/1kGKmSeD1B0duOHhEHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.96.tgz",
+      "integrity": "sha512-Dx/0+RFV++w3PcRy+4xNXkghhXjA5d0Mw1bs95emn5Llinp1vihMaA6WJt3oYv2LAHc36+gnrhIBsPhUyI2SGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.96.tgz",
+      "integrity": "sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.96.tgz",
+      "integrity": "sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.96.tgz",
+      "integrity": "sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.96.tgz",
+      "integrity": "sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.96.tgz",
+      "integrity": "sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.96.tgz",
+      "integrity": "sha512-UYGdTltVd+Z8mcIuoqGmAXXUvwH5CLf2M6mIB5B0/JmX5J041jETjqtSYl7gN+aj3k1by/SG6sS0hAwCqyK7zw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1732,7 +1983,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2814,6 +3065,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2880,7 +3140,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3003,6 +3263,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -4678,7 +4947,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5095,7 +5363,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5133,6 +5400,24 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5141,6 +5426,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge2": {
@@ -5576,6 +5878,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5714,6 +6028,35 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6348,6 +6691,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6682,6 +7031,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-pdf": "^10.4.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/components/practice/SlideViewer.tsx
+++ b/src/components/practice/SlideViewer.tsx
@@ -1,14 +1,232 @@
 "use client";
 
-/**
- * SlideViewer コンポーネント
- * TODO: メンバー1 - PDFアップロード＆表示を実装
- */
+import { useState, useCallback, useRef } from "react";
+import { Document, Page, pdfjs } from "react-pdf";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+import { ChevronLeft, ChevronRight, Upload, FileText, Loader2 } from "lucide-react";
+import { uploadSlidePdf } from "@/src/lib/storage";
 
-export default function SlideViewer() {
+// react-pdf のワーカーを CDN から読み込む
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+
+interface SlideViewerProps {
+    /** 練習セッション ID（Supabase Storage のパスに使用） */
+    sessionId?: string;
+}
+
+export default function SlideViewer({ sessionId = "default" }: SlideViewerProps) {
+    const [pdfFile, setPdfFile] = useState<File | null>(null);
+    const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+    const [numPages, setNumPages] = useState<number>(0);
+    const [currentPage, setCurrentPage] = useState<number>(1);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // ファイルを選択・ドロップしたときの共通処理
+    const handleFile = useCallback(
+        async (file: File) => {
+            if (file.type !== "application/pdf") {
+                setUploadError("PDFファイルのみアップロードできます。");
+                return;
+            }
+            setUploadError(null);
+            setPdfFile(file);
+            setCurrentPage(1);
+
+            // ローカルプレビュー用の ObjectURL を生成
+            const localUrl = URL.createObjectURL(file);
+            setPdfUrl(localUrl);
+
+            // Supabase Storage へバックグラウンドアップロード
+            setIsUploading(true);
+            try {
+                await uploadSlidePdf(file, sessionId);
+            } catch (err) {
+                console.warn("Supabase upload failed:", err);
+                // アップロード失敗はプレビュー表示には影響させない
+                setUploadError("クラウド保存に失敗しました（ローカルプレビューは表示されます）。");
+            } finally {
+                setIsUploading(false);
+            }
+        },
+        [sessionId]
+    );
+
+    // ドラッグ＆ドロップ
+    const onDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+    const onDragLeave = () => setIsDragging(false);
+    const onDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+        const file = e.dataTransfer.files[0];
+        if (file) handleFile(file);
+    };
+
+    // ボタン経由のファイル選択
+    const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) handleFile(file);
+    };
+
+    // ページナビゲーション
+    const prevPage = () => setCurrentPage((p) => Math.max(1, p - 1));
+    const nextPage = () => setCurrentPage((p) => Math.min(numPages, p + 1));
+
+    // ---- 未アップロード時の UI ----
+    if (!pdfFile) {
+        return (
+            <div
+                className={`h-full flex flex-col items-center justify-center gap-4 transition-colors duration-200 cursor-pointer select-none
+                    ${isDragging
+                        ? "bg-blue-50 border-2 border-dashed border-blue-400"
+                        : "bg-gray-50 border-2 border-dashed border-gray-300 hover:border-blue-400 hover:bg-blue-50"
+                    }`}
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+                onDrop={onDrop}
+                onClick={() => fileInputRef.current?.click()}
+                role="button"
+                aria-label="PDFファイルをアップロード"
+            >
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="application/pdf"
+                    className="hidden"
+                    onChange={onFileChange}
+                />
+                <div className={`p-4 rounded-full transition-colors duration-200 ${isDragging ? "bg-blue-100" : "bg-gray-100"}`}>
+                    <FileText
+                        size={40}
+                        className={`transition-colors duration-200 ${isDragging ? "text-blue-500" : "text-gray-400"}`}
+                    />
+                </div>
+                <div className="text-center">
+                    <p className={`font-semibold text-sm transition-colors duration-200 ${isDragging ? "text-blue-600" : "text-gray-600"}`}>
+                        {isDragging ? "ここにドロップ" : "スライド（PDF）をアップロード"}
+                    </p>
+                    <p className="text-xs text-gray-400 mt-1">
+                        ドラッグ＆ドロップ、またはクリックして選択
+                    </p>
+                </div>
+                <button
+                    className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:scale-95 transition-all duration-150 shadow-sm"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        fileInputRef.current?.click();
+                    }}
+                >
+                    <Upload size={16} />
+                    ファイルを選択
+                </button>
+                {uploadError && (
+                    <p className="text-xs text-red-500 max-w-xs text-center px-4">{uploadError}</p>
+                )}
+            </div>
+        );
+    }
+
+    // ---- PDF 表示 UI ----
     return (
-        <div className="h-full flex items-center justify-center">
-            <p className="text-foreground-muted">スライド表示エリア</p>
+        <div className="h-full flex flex-col bg-gray-800">
+            {/* PDF 表示エリア */}
+            <div className="flex-1 overflow-auto flex items-center justify-center p-2">
+                <Document
+                    file={pdfUrl}
+                    onLoadSuccess={({ numPages }) => {
+                        setNumPages(numPages);
+                        setCurrentPage(1);
+                    }}
+                    loading={
+                        <div className="flex flex-col items-center gap-2 text-gray-300">
+                            <Loader2 size={28} className="animate-spin" />
+                            <span className="text-sm">PDF を読み込み中...</span>
+                        </div>
+                    }
+                    error={
+                        <div className="text-red-400 text-sm text-center px-4">
+                            PDF の読み込みに失敗しました。
+                        </div>
+                    }
+                >
+                    <Page
+                        pageNumber={currentPage}
+                        renderTextLayer={true}
+                        renderAnnotationLayer={true}
+                        className="shadow-lg"
+                        width={Math.min(typeof window !== "undefined" ? window.innerWidth * 0.45 : 600, 700)}
+                    />
+                </Document>
+            </div>
+
+            {/* ナビゲーションバー */}
+            <div className="flex items-center justify-between px-4 py-2 bg-gray-900 text-white">
+                {/* 左: ファイル名 + アップロード状態 */}
+                <div className="flex items-center gap-2 min-w-0">
+                    <FileText size={14} className="text-gray-400 shrink-0" />
+                    <span className="text-xs text-gray-300 truncate max-w-[180px]">
+                        {pdfFile.name}
+                    </span>
+                    {isUploading && (
+                        <span className="flex items-center gap-1 text-xs text-blue-400 shrink-0">
+                            <Loader2 size={10} className="animate-spin" />
+                            保存中...
+                        </span>
+                    )}
+                    {uploadError && !isUploading && (
+                        <span className="text-xs text-yellow-400 shrink-0" title={uploadError}>
+                            ⚠ 保存失敗
+                        </span>
+                    )}
+                </div>
+
+                {/* 中央: ページナビゲーション */}
+                <div className="flex items-center gap-2">
+                    <button
+                        onClick={prevPage}
+                        disabled={currentPage <= 1}
+                        aria-label="前のページ"
+                        className="p-1.5 rounded-md hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors duration-150"
+                    >
+                        <ChevronLeft size={18} />
+                    </button>
+                    <span className="text-sm font-mono tabular-nums min-w-[70px] text-center">
+                        {currentPage} / {numPages || "-"}
+                    </span>
+                    <button
+                        onClick={nextPage}
+                        disabled={currentPage >= numPages}
+                        aria-label="次のページ"
+                        className="p-1.5 rounded-md hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors duration-150"
+                    >
+                        <ChevronRight size={18} />
+                    </button>
+                </div>
+
+                {/* 右: 差し替えボタン */}
+                <div>
+                    <input
+                        type="file"
+                        accept="application/pdf"
+                        className="hidden"
+                        id="slide-replace-input"
+                        onChange={onFileChange}
+                    />
+                    <label
+                        htmlFor="slide-replace-input"
+                        className="flex items-center gap-1 text-xs text-gray-400 hover:text-white cursor-pointer transition-colors duration-150"
+                    >
+                        <Upload size={13} />
+                        差し替え
+                    </label>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,27 @@
+import { supabase } from "./supabase";
+
+/**
+ * Supabase Storage の "slides" バケットに PDF をアップロードし、
+ * 公開 URL を返す。
+ *
+ * @param file - アップロードする PDF ファイル
+ * @param sessionId - 練習セッション ID（ファイル名のプレフィックスに使用）
+ * @returns 公開 URL（string）
+ * @throws アップロード失敗時に Error をスロー
+ */
+export async function uploadSlidePdf(
+    file: File,
+    sessionId: string
+): Promise<string> {
+    const ext = file.name.split(".").pop() ?? "pdf";
+    const path = `${sessionId}/${Date.now()}.${ext}`;
+
+    const { error } = await supabase.storage
+        .from("slides")
+        .upload(path, file, { upsert: true });
+
+    if (error) throw new Error(error.message);
+
+    const { data } = supabase.storage.from("slides").getPublicUrl(path);
+    return data.publicUrl;
+}


### PR DESCRIPTION
Issue#1 スライド表示エリアの実装

●追加したファイル
・src/components/practice/SlideViewer.tsx（メインのスライド表示コンポーネント）　
　以下の機能を含む。
　・PDFファイルのドラッグ＆ドロップ / ボタンによるアップロードUI
　・react-pdf を使ったPDFのページ単位表示
　・前ページ / 次ページのボタン（ページ番号表示付き）
　・アップロード後の差し替え可能
・src/lib/storage.ts　Supabase Storage の slides バケットにPDFをアップロードし、公開URLを返す関数uploadSlidePdf()を実装。

●変更したファイル
・app/practice/[id]/page.tsx
　・<SlideViewer /> に sessionId={id} を渡すよう変更（Storage上のパスをセッションごとに分離するため）。
　・react-pdf がSSR非対応のため next/dynamic の ssr: false で動的インポートに変更。
　　→react-pdfはブラウザ専用のAPIを使っているため、Next.jsに対してサーバー側での実行をスキップさせ、ブラウザ環境でだけ react-pdf が動くようにする。

●Supabase 側の設定
・slidesバケットを作成し、RLS(Row level security)ポリシーを設定。
　SQL Editorで以下の2つのポリシーを追加。

-- 匿名ユーザーのアップロードを許可
CREATE POLICY "Allow anon uploads" ON storage.objects
FOR INSERT TO anon WITH CHECK (bucket_id = 'slides');

-- 匿名ユーザーの読み取りを許可
CREATE POLICY "Allow anon select" ON storage.objects
FOR SELECT TO anon USING (bucket_id = 'slides');


　


