### PR TITLE
5-チャット履歴のDB保存・復元、松本

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,13 +1,19 @@
 import { GoogleGenAI } from '@google/genai';
+import { saveMessage } from '@/src/lib/messages';
 
 const client = new GoogleGenAI({ apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? '' });
 
 export async function POST(req: Request) {
     try {
-        const { sessionId: _sessionId, message, persona } = await req.json();
+        const { sessionId, message, persona } = await req.json();
 
         if (!message) {
             return Response.json({ error: 'message は必須です' }, { status: 400 });
+        }
+
+        // ユーザーのメッセージを保存
+        if (sessionId) {
+            await saveMessage(sessionId, 'user', message);
         }
 
         const systemInstruction = persona
@@ -37,10 +43,14 @@ export async function POST(req: Request) {
                         }
                     }
 
-
                     const emotionMatch = fullText.match(/emotion:\s*(.+)/);
                     const emotion = emotionMatch ? emotionMatch[1].trim() : 'neutral';
                     controller.enqueue(encoder.encode(`data: ${JSON.stringify({ emotion })}\n\n`));
+
+                    // AIの応答をDBに保存
+                    if (sessionId) {
+                        await saveMessage(sessionId, 'assistant', fullText, emotion);
+                    }
 
                     controller.enqueue(encoder.encode('data: [DONE]\n\n'));
                 } catch (err) {

--- a/app/api/chat_logs/[sessionId]/route.ts
+++ b/app/api/chat_logs/[sessionId]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { fetchMessages } from "@/src/lib/messages";
+
+export async function GET(
+    _req: Request,
+    { params }: { params: Promise<{ sessionId: string }> }
+) {
+    const { sessionId } = await params;
+
+    if (!sessionId) {
+        return NextResponse.json({ error: "sessionId is required" }, { status: 400 });
+    }
+
+    const messages = await fetchMessages(sessionId);
+    return NextResponse.json({ messages });
+}

--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -22,7 +22,26 @@ export default function PracticePage({
 
     const [messages, setMessages] = useState<Message[]>([]);
     const [streamingText, setStreamingText] = useState<string | null>(null);
+    const [historyLoading, setHistoryLoading] = useState(true);
     const bottomRef = useRef<HTMLDivElement | null>(null);
+
+    // セッション開始時にDBから過去のメッセージ履歴を取得
+    useEffect(() => {
+        async function loadHistory() {
+            try {
+                const res = await fetch(`/api/chat_logs/${id}`);
+                if (res.ok) {
+                    const { messages: history } = await res.json();
+                    setMessages(history ?? []);
+                }
+            } catch (err) {
+                console.error("履歴の取得に失敗しました:", err);
+            } finally {
+                setHistoryLoading(false);
+            }
+        }
+        loadHistory();
+    }, [id]);
 
     // 新しいメッセージ・ストリーミング更新のたびに自動スクロール
     useEffect(() => {
@@ -84,7 +103,9 @@ export default function PracticePage({
                 <div className="w-[420px] flex flex-col bg-white">
                     {/* AIコメント表示エリア（スクロール） */}
                     <div className="flex-1 overflow-y-auto p-4 space-y-3">
-                        {messages.length === 0 && streamingText === null ? (
+                        {historyLoading ? (
+                            <p className="text-foreground-muted text-sm">履歴を読み込み中...</p>
+                        ) : messages.length === 0 && streamingText === null ? (
                             <p className="text-foreground-muted text-sm">
                                 AIのコメントがここに表示されます
                             </p>
@@ -143,19 +164,19 @@ export default function PracticePage({
 
             {/* 人物像設定モーダル */}
             {isPersonaModalOpen && (
-                <div 
+                <div
                     className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
                     onClick={() => setIsPersonaModalOpen(false)}
                 >
-                    <div 
+                    <div
                         className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <h2 className="text-xl font-bold mb-4">AIの人物像設定</h2>
 
-                        <PersonaConfig 
+                        <PersonaConfig
                             sessionId={id}
-                            onSaveSuccess={() => setIsPersonaModalOpen(false)} 
+                            onSaveSuccess={() => setIsPersonaModalOpen(false)}
                         />
 
                         <div className="mt-6 flex justify-end gap-3">
@@ -173,19 +194,19 @@ export default function PracticePage({
 
             {/* 前提知識アップロードモーダル */}
             {isKnowledgeModalOpen && (
-                <div 
+                <div
                     className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
                     onClick={() => setIsKnowledgeModalOpen(false)}
                 >
-                    <div 
+                    <div
                         className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <h2 className="text-xl font-bold mb-4">前提知識のアップロード</h2>
 
-                        <KnowledgeUpload 
+                        <KnowledgeUpload
                             sessionId={id}
-                            onSaveSuccess={() => setIsKnowledgeModalOpen(false)} 
+                            onSaveSuccess={() => setIsKnowledgeModalOpen(false)}
                         />
 
                         <div className="mt-6 flex justify-end gap-3">

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,72 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Message } from "@/src/components/practice/ChatInterface";
+
+/**
+ * サーバーサイド用 Supabase クライアント。
+ * サービスロールキーがあればそちらを使い、なければ anonキーで代替する。
+ */
+function getServerClient() {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const key =
+        process.env.SUPABASE_SERVICE_ROLE_KEY ??
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+    return createClient(url, key);
+}
+
+export type MessageRole = "user" | "assistant";
+
+/**
+ * messages テーブルに1件のメッセージを保存する。
+ *
+ * @param sessionId - 練習セッション ID
+ * @param role      - "user" または "assistant"
+ * @param content   - メッセージ本文
+ * @param emotion   - AI の感情（assistant の場合のみ）
+ */
+export async function saveMessage(
+    sessionId: string,
+    role: MessageRole,
+    content: string,
+    emotion?: string
+): Promise<void> {
+    const supabase = getServerClient();
+
+    const { error } = await supabase.from("chat_logs").insert({
+        session_id: sessionId,
+        role,
+        content,
+        emotion: emotion ?? null,
+    });
+
+    if (error) {
+        // 保存失敗はログに出すが、チャットの応答は止めない
+        console.error("[messages] 保存失敗:", error.message);
+    }
+}
+
+/**
+ * messages テーブルから指定セッションの履歴を取得する。
+ *
+ * @param sessionId - 練習セッション ID
+ * @returns Message の配列（作成日時昇順）
+ */
+export async function fetchMessages(sessionId: string): Promise<Message[]> {
+    const supabase = getServerClient();
+
+    const { data, error } = await supabase
+        .from("chat_logs")
+        .select("role, content, emotion")
+        .eq("session_id", sessionId)
+        .order("created_at", { ascending: true });
+
+    if (error) {
+        console.error("[messages] 履歴取得失敗:", error.message);
+        return [];
+    }
+
+    return (data ?? []).map((row) => ({
+        role: row.role as Message["role"],
+        text: row.content as string,
+        emotion: row.emotion ?? undefined,
+    }));
+}


### PR DESCRIPTION
# app\api\chat_logs\[sessionId]\route.ts　の内容
## 目的
- 特定のセッションに紐づくチャット履歴を返す GETのAPIエンドポイント
## URL の形式
- GET /api/chat_logs/{sessionId} という形でアクセスされる
-  {sessionId} はURLの一部として渡される（例: /api/chat_logs/d14f5a40-...）
## 処理の流れ
- URLから sessionId を取り出す
- sessionId がなければ 400 エラー を返して終了
- fetchMessages(sessionId)を呼び出して Supabase の chat_logs テーブルから過去の会話を取得
- 取得した会話データを JSON 形式でレスポンスとして返す
## 呼び出し元
- app/practice/[id]/page.tsxがページを開いたときに fetch("/api/chat_logs/{id}")でこのAPIを叩き、過去のチャット履歴を画面に表示する



# app\api\chat\route.tsの変更内容
- 今回の実装で追加した変更は2行目・14〜17行目・50〜53行目の3箇所
## saveMessageのインポートを追加（2行目）
- DB保存用のヘルパー関数を使えるようにした
## ユーザーのメッセージを保存（14〜17行目)
- リクエストを受け取った直後にユーザーの発言を chat_logs テーブルへ保存
- sessionId がない場合（例: URLが変な場合）はスキップする
## AIの応答と emotion を保存（50〜53行目)
- AIのストリーミングが全部終わった後に、応答の全文と感情（emotion）をまとめて chat_logs テーブルへ保存
- emotion は直前の行で正規表現（/emotion:\s*(.+)/）でAIの返答から自動抽出したもの


# src\lib\messages.tsの内容
## 役割
- Supabase の chat_logs テーブルに対してメッセージの「保存」と「取得」を行う共通ヘルパーファイル。サーバー側（API Route）からのみ使用する。
## getServerClient()関数
- サーバーサイド専用の Supabase クライアントを作成する内部関数
- 環境変数 SUPABASE_SERVICE_ROLE_KEY（サービスロールキー）を優先して使用
- サービスロールキーがなければ NEXT_PUBLIC_SUPABASE_ANON_KEY（通常キー）で代替
## saveMessage()関数
- 用途: 1件のメッセージを chat_logs テーブルに保存する
- 引数:
- sessionId — どのセッションのメッセージか
- role — "user"（ユーザー）または "assistant"（AI）
- content — メッセージ本文
- emotion — AIの感情（省略可。ユーザーメッセージでは不要）
- エラー処理: 保存に失敗してもコンソールにログを出すだけで、チャットの動作は止めない



## fetchMessages()関数
- 用途: chat_logs テーブルから指定セッションの会話履歴を全件取得する
- 返り値: Message[] 形式（role, text, emotion を持つ配列）
- 並び順: created_at の昇順（古い発言が先頭）
- エラー処理: 取得失敗時は空配列 [] を返す


# app\practice\[id]\page.tsxの変更内容
## historyLoading ステートの追加
- 「履歴を読み込んでいる最中かどうか」を管理するフラグを新設
- 初期値は true（ページを開いた瞬間はロード中）
## ページ読み込み時に履歴を取得する useEffect の追加
- ページを開いたとき（または idが変わったとき）に自動で実行される
- /api/chat_logs/{sessionId} にリクエストを送り、過去の会話履歴をDBから取得する
- 取得したデータを messages ステートにセットすることで、画面に過去の会話が表示される
- 成功・失敗どちらの場合も最後に historyLoading を false にしてロード完了を知らせる
## 履歴ロード中の表示切り替え
- ロード中: 「履歴を読み込み中...」を表示
- ロード完了・メッセージなし: 「AIのコメントがここに表示されます」を表示（以前からある動作）
- ロード完了・メッセージあり: 取得した過去の会話を一覧表示