### PR TITLE
11-スライド別音声録音UIの実装 #11

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -7,6 +7,10 @@ const SlideViewer = dynamic(
     () => import("@/src/components/practice/SlideViewer"),
     { ssr: false }
 );
+const SlideRecorder = dynamic(
+    () => import("@/src/components/practice/SlideRecorder"),
+    { ssr: false }
+);
 import ChatInterface, { Message } from "@/src/components/practice/ChatInterface";
 import PersonaConfig from "@/src/components/setup/PersonaConfig";
 import KnowledgeUpload from "@/src/components/setup/KnowledgeUpload";
@@ -19,6 +23,18 @@ export default function PracticePage({
     const { id } = use(params);
     const [isPersonaModalOpen, setIsPersonaModalOpen] = useState(false);
     const [isKnowledgeModalOpen, setIsKnowledgeModalOpen] = useState(false);
+
+    // スライドの現在ページ・総ページ数（SlideRecorder との共有）
+    const [currentPage, setCurrentPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(0);
+
+    const handleFeedbackReady = useCallback(
+        (slideAudios: { page: number; blob: Blob }[]) => {
+            // TODO: 録音データを AI フィードバック API に送信する
+            console.log("[Logeach] フィードバック依頼:", slideAudios);
+        },
+        []
+    );
 
     const [messages, setMessages] = useState<Message[]>([]);
     const [streamingText, setStreamingText] = useState<string | null>(null);
@@ -66,7 +82,20 @@ export default function PracticePage({
                 <div className="flex-1 flex flex-col border-r border-border">
                     {/* 左上: スライド */}
                     <div className="flex-1 border-b border-border">
-                        <SlideViewer sessionId={id} />
+                        <SlideViewer
+                            sessionId={id}
+                            onPageChange={setCurrentPage}
+                            onNumPagesReady={setTotalPages}
+                        />
+                    </div>
+                    {/* 左中: 録音コントローラー */}
+                    <div className="px-4 py-2 bg-gray-950">
+                        <SlideRecorder
+                            totalPages={totalPages}
+                            currentPage={currentPage}
+                            sessionId={id}
+                            onFeedbackReady={handleFeedbackReady}
+                        />
                     </div>
                     {/* 左下: AIに反論 */}
                     <div className="p-4 bg-white">
@@ -143,19 +172,19 @@ export default function PracticePage({
 
             {/* 人物像設定モーダル */}
             {isPersonaModalOpen && (
-                <div 
+                <div
                     className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
                     onClick={() => setIsPersonaModalOpen(false)}
                 >
-                    <div 
+                    <div
                         className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <h2 className="text-xl font-bold mb-4">AIの人物像設定</h2>
 
-                        <PersonaConfig 
+                        <PersonaConfig
                             sessionId={id}
-                            onSaveSuccess={() => setIsPersonaModalOpen(false)} 
+                            onSaveSuccess={() => setIsPersonaModalOpen(false)}
                         />
 
                         <div className="mt-6 flex justify-end gap-3">
@@ -173,19 +202,19 @@ export default function PracticePage({
 
             {/* 前提知識アップロードモーダル */}
             {isKnowledgeModalOpen && (
-                <div 
+                <div
                     className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:p-6 overflow-y-auto"
                     onClick={() => setIsKnowledgeModalOpen(false)}
                 >
-                    <div 
+                    <div
                         className="bg-background rounded-xl shadow-lg w-full max-w-md p-6 my-auto"
                         onClick={(e) => e.stopPropagation()}
                     >
                         <h2 className="text-xl font-bold mb-4">前提知識のアップロード</h2>
 
-                        <KnowledgeUpload 
+                        <KnowledgeUpload
                             sessionId={id}
-                            onSaveSuccess={() => setIsKnowledgeModalOpen(false)} 
+                            onSaveSuccess={() => setIsKnowledgeModalOpen(false)}
                         />
 
                         <div className="mt-6 flex justify-end gap-3">

--- a/src/components/practice/SlideRecorder.tsx
+++ b/src/components/practice/SlideRecorder.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+interface SlideRecorderProps {
+    totalPages: number;
+    currentPage: number;
+    sessionId: string;
+    onFeedbackReady: (slideAudios: { page: number; blob: Blob }[]) => void;
+}
+
+type RecordingState = "idle" | "recording" | "done";
+
+function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export default function SlideRecorder({
+    totalPages,
+    currentPage,
+    sessionId,
+    onFeedbackReady,
+}: SlideRecorderProps) {
+    const [recordingState, setRecordingState] = useState<RecordingState>("idle");
+    const [pageElapsed, setPageElapsed] = useState(0);
+    const [slideAudios, setSlideAudios] = useState<{ page: number; blob: Blob }[]>([]);
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+    const mediaStreamRef = useRef<MediaStream | null>(null);
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    // 現在「録音中」のページ番号を追跡する ref
+    // （currentPage の useEffect と競合しないよう手動で管理する）
+    const recordingPageRef = useRef(currentPage);
+
+    // タイマーをリセット・開始
+    const startTimer = useCallback(() => {
+        if (timerRef.current) clearInterval(timerRef.current);
+        setPageElapsed(0);
+        timerRef.current = setInterval(() => {
+            setPageElapsed((prev) => prev + 1);
+        }, 1000);
+    }, []);
+
+    const stopTimer = useCallback(() => {
+        if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+        }
+    }, []);
+
+    // 現在の MediaRecorder を停止し、blob を slideAudios に追加する
+    // 追加後に onStarted() コールバックを呼ぶことで新しい録音を連鎖できる
+    const stopCurrentRecording = useCallback(
+        (page: number, onStopped?: (audios: { page: number; blob: Blob }[]) => void) => {
+            const mr = mediaRecorderRef.current;
+            if (!mr || mr.state === "inactive") {
+                onStopped?.(slideAudios);
+                return;
+            }
+
+            mr.ondataavailable = (e) => {
+                if (e.data.size > 0) chunksRef.current.push(e.data);
+            };
+            mr.onstop = () => {
+                const blob = new Blob(chunksRef.current, { type: mr.mimeType || "audio/webm" });
+                chunksRef.current = [];
+                setSlideAudios((prev) => {
+                    const updated = [...prev, { page, blob }];
+                    onStopped?.(updated);
+                    return updated;
+                });
+            };
+            mr.stop();
+        },
+        [slideAudios]
+    );
+
+    // MediaRecorder を新規作成して録音開始
+    const startNewRecording = useCallback((stream: MediaStream) => {
+        chunksRef.current = [];
+        const mr = new MediaRecorder(stream);
+        mr.ondataavailable = (e) => {
+            if (e.data.size > 0) chunksRef.current.push(e.data);
+        };
+        mr.start();
+        mediaRecorderRef.current = mr;
+    }, []);
+
+    // 「録音開始」クリック
+    const handleStart = useCallback(async () => {
+        setErrorMsg(null);
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            mediaStreamRef.current = stream;
+            recordingPageRef.current = currentPage; // 録音開始時のページを記録
+            startNewRecording(stream);
+            setRecordingState("recording");
+            startTimer();
+        } catch {
+            setErrorMsg("マイクへのアクセスが拒否されました。ブラウザの設定を確認してください。");
+        }
+    }, [currentPage, startNewRecording, startTimer]);
+
+    // 「録音終了」クリック
+    const handleStop = useCallback(() => {
+        stopTimer();
+        const page = recordingPageRef.current; // 現在録音中だったページ
+        const mr = mediaRecorderRef.current;
+        if (!mr || mr.state === "inactive") {
+            setRecordingState("done");
+            return;
+        }
+
+        mr.ondataavailable = (e) => {
+            if (e.data.size > 0) chunksRef.current.push(e.data);
+        };
+        mr.onstop = () => {
+            const blob = new Blob(chunksRef.current, { type: mr.mimeType || "audio/webm" });
+            chunksRef.current = [];
+            setSlideAudios((prev) => {
+                const updated = [...prev, { page, blob }];
+                return updated;
+            });
+            // ストリームを解放
+            mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+            mediaStreamRef.current = null;
+            mediaRecorderRef.current = null;
+            setRecordingState("done");
+        };
+        mr.stop();
+    }, [stopTimer]);
+
+    // 「AIにフィードバックを依頼する」クリック
+    const handleFeedback = useCallback(() => {
+        onFeedbackReady(slideAudios);
+    }, [onFeedbackReady, slideAudios]);
+
+    // currentPage が変わったら区切りを入れる（録音中のみ）
+    useEffect(() => {
+        if (recordingState !== "recording") return;
+
+        const stream = mediaStreamRef.current;
+        if (!stream) return;
+
+        // この時点で recordingPageRef には「前のページ」が入っている
+        const pageJustFinished = recordingPageRef.current;
+        // 次のページを記録してから前のページの録音を止める
+        recordingPageRef.current = currentPage;
+        stopCurrentRecording(pageJustFinished, () => {
+            startNewRecording(stream);
+            startTimer();
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentPage]);
+
+    // アンマウント時にクリーンアップ
+    useEffect(() => {
+        return () => {
+            stopTimer();
+            mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+        };
+    }, [stopTimer]);
+
+    // ---- UI ----
+    return (
+        <div className="border border-gray-700 rounded-lg p-3 bg-gray-900 text-white font-mono text-sm select-none">
+            {recordingState === "idle" && (
+                <div className="flex flex-col gap-2">
+                    {errorMsg && (
+                        <p className="text-red-400 text-xs">{errorMsg}</p>
+                    )}
+                    <button
+                        onClick={handleStart}
+                        disabled={totalPages === 0}
+                        className="flex items-center justify-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed rounded-md text-sm font-semibold transition-colors duration-150"
+                    >
+                        <span className="text-base leading-none">⏺</span>
+                        録音開始
+                    </button>
+                    {totalPages === 0 && (
+                        <p className="text-gray-400 text-xs text-center">
+                            スライドをアップロードしてから録音できます
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {recordingState === "recording" && (
+                <div className="flex flex-col gap-2">
+                    {/* REC インジケーター */}
+                    <div className="flex items-center gap-2">
+                        <span className="animate-pulse text-red-500 text-base leading-none">●</span>
+                        <span className="text-red-400 font-bold">REC</span>
+                        <span className="text-gray-300">
+                            スライド {currentPage}
+                            {totalPages > 0 ? `/${totalPages}` : ""}
+                        </span>
+                    </div>
+                    {/* タイマー + 録音終了ボタン */}
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-gray-200 tabular-nums">{formatTime(pageElapsed)}</span>
+                        <button
+                            onClick={handleStop}
+                            className="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded-md text-xs font-semibold transition-colors duration-150 border border-gray-600"
+                        >
+                            録音終了
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {recordingState === "done" && (
+                <div className="flex flex-col gap-2">
+                    <p className="text-green-400 text-xs">
+                        ✓ 録音完了（{slideAudios.length} ページ分）
+                    </p>
+                    <button
+                        onClick={handleFeedback}
+                        className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-md text-sm font-semibold transition-colors duration-150"
+                    >
+                        AIにフィードバックを依頼する
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/practice/SlideViewer.tsx
+++ b/src/components/practice/SlideViewer.tsx
@@ -15,9 +15,17 @@ const storageKey = (sessionId: string) => `slide_pdf_${sessionId}`;
 interface SlideViewerProps {
     /** 練習セッション ID（Supabase Storage のパスに使用） */
     sessionId?: string;
+    /** ページが変わったときに呼ばれるコールバック */
+    onPageChange?: (newPage: number) => void;
+    /** PDF の総ページ数が確定したときに呼ばれるコールバック */
+    onNumPagesReady?: (totalPages: number) => void;
 }
 
-export default function SlideViewer({ sessionId = "default" }: SlideViewerProps) {
+export default function SlideViewer({
+    sessionId = "default",
+    onPageChange,
+    onNumPagesReady,
+}: SlideViewerProps) {
     const [pdfUrl, setPdfUrl] = useState<string | null>(null);
     const [pdfFileName, setPdfFileName] = useState<string | null>(null);
     const [numPages, setNumPages] = useState<number>(0);
@@ -96,8 +104,16 @@ export default function SlideViewer({ sessionId = "default" }: SlideViewerProps)
     };
 
     // ページナビゲーション
-    const prevPage = () => setCurrentPage((p) => Math.max(1, p - 1));
-    const nextPage = () => setCurrentPage((p) => Math.min(numPages, p + 1));
+    const prevPage = () => {
+        const next = Math.max(1, currentPage - 1);
+        setCurrentPage(next);
+        if (next !== currentPage) onPageChange?.(next);
+    };
+    const nextPage = () => {
+        const next = Math.min(numPages, currentPage + 1);
+        setCurrentPage(next);
+        if (next !== currentPage) onPageChange?.(next);
+    };
 
     // ---- 未アップロード時の UI ----
     if (!pdfUrl) {
@@ -163,6 +179,7 @@ export default function SlideViewer({ sessionId = "default" }: SlideViewerProps)
                     onLoadSuccess={({ numPages }) => {
                         setNumPages(numPages);
                         setCurrentPage(1);
+                        onNumPagesReady?.(numPages);
                     }}
                     loading={
                         <div className="flex flex-col items-center gap-2 text-gray-300">


### PR DESCRIPTION
# 目的
- スライドを表示しながら、ページごとに音声を自動で区切って録音する機能を実装する。
- 「次のスライドへ」を押すと前のページの録音が確定され、新しい録音が始まる。
- 録音修了後、「AIにフィードバックを依頼する」ボタンを表示する。

## SlideRecorder.tsx（新規作成）
ブラウザ標準の MediaRecorder API を使い、以下の動作を実現するコンポーネントを新規作成した。
- 「録音開始」ボタン — getUserMedia({ audio: true }) でマイク許可を取得し、録音セッションを開始。
- ページごとの録音区切り — スライドのページが変わるたびに MediaRecorder を一度停止し、完了したページの音声を { page: number; blob: Blob } の形式で配列に保存。新しいページの録音を即座に開始。
- 録音中のインジケーター — ● REC スライド n/N と現在ページの経過時間をリアルタイム表示。
- 「録音終了」ボタン — 現在録音中のページの音声を確定し、マイクストリームを解放。
- 「AIにフィードバックを依頼する」ボタン — 録音完了後に表示。全スライドの Blob 配列を onFeedbackReady コールバックで親コンポーネントに渡す。

## SlideViewer.tsx（修正）
SlideRecorder との連携のため、以下の props を追加した。
- onPageChange?: (newPage: number) => void — 前へ/次へボタン押下時に新しいページ番号を通知。
- onNumPagesReady?: (totalPages: number) => void — PDF 読み込み完了時に総ページ数を通知。

## practice/[id]/page.tsx（修正）
- currentPage / totalPages の state を SlideViewer から page.tsx に引き上げ。
- SlideViewer に onPageChange / onNumPagesReady を接続。
- SlideRecorder をスライドビューの直下に配置。
- onFeedbackReady のプレースホルダーを実装（現在は console.log、今後 AI API 連携を追加予定）。
