### PR TITLE
21-スライドPDFをAI APIに渡して内容を踏まえた返答を生成する #21

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,11 +1,11 @@
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, type ContentListUnion } from '@google/genai';
 import { saveMessage } from '@/src/lib/messages';
 
 const client = new GoogleGenAI({ apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? '' });
 
 export async function POST(req: Request) {
     try {
-        const { sessionId, message, persona } = await req.json();
+        const { sessionId, message, persona, slideUrl } = await req.json();
 
         if (!message) {
             return Response.json({ error: 'message は必須です' }, { status: 400 });
@@ -16,14 +16,35 @@ export async function POST(req: Request) {
             await saveMessage(sessionId, 'user', message);
         }
 
+        const slideInstruction = slideUrl
+            ? 'ユーザーが添付したスライドの内容を踏まえて反論・コメントしてください。'
+            : '';
+
         const systemInstruction = persona
-            ? `あなたは${persona}として振る舞ってください。返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください（例: emotion: 興味深い）。`
-            : '返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください（例: emotion: 興味深い）。';
+            ? `あなたは${persona}として振る舞ってください。${slideInstruction}返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください（例: emotion: 興味深い）。`
+            : `${slideInstruction}返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください（例: emotion: 興味深い）。`;
+
+
+        let contents: ContentListUnion;
+        if (slideUrl) {
+            // fileData.fileUri は Gemini Files API の URI 専用のため、
+            // 任意の公開URL（Supabase 等）は fetch して base64 に変換して渡す
+            const pdfRes = await fetch(slideUrl);
+            if (!pdfRes.ok) throw new Error(`PDF fetch failed: ${pdfRes.status}`);
+            const pdfBuffer = await pdfRes.arrayBuffer();
+            const pdfBase64 = Buffer.from(pdfBuffer).toString('base64');
+            contents = [
+                { inlineData: { mimeType: 'application/pdf', data: pdfBase64 } },
+                { text: message },
+            ];
+        } else {
+            contents = message;
+        }
 
 
         const result = await client.models.generateContentStream({
             model: 'gemini-2.5-flash',
-            contents: message,
+            contents,
             config: {
                 systemInstruction,
             },

--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -29,12 +29,15 @@ export default function PracticePage({
     const [currentPage, setCurrentPage] = useState(1);
     const [totalPages, setTotalPages] = useState(0);
 
+    // localStorage からスライドURLを読み取る（SlideViewer の onPdfUrlReady で更新）
+    const [slideUrl, setSlideUrl] = useState<string | null>(null);
+
     const handleFeedbackReady = useCallback(
         (slideAudios: { page: number; blob: Blob }[]) => {
-            // TODO: 録音データを AI フィードバック API に送信する
-            console.log("[Logeach] フィードバック依頼:", slideAudios);
+            // TODO: 録音データを AI フィードバック API に送信する（slideUrl も渡す）
+            console.log("[Logeach] フィードバック依頼:", slideAudios, "slideUrl:", slideUrl);
         },
-        []
+        [slideUrl]
     );
 
     const [messages, setMessages] = useState<Message[]>([]);
@@ -106,6 +109,7 @@ export default function PracticePage({
                             sessionId={id}
                             onPageChange={setCurrentPage}
                             onNumPagesReady={setTotalPages}
+                            onPdfUrlReady={setSlideUrl}
                         />
                     </div>
                     {/* 左中: 録音コントローラー */}
@@ -122,6 +126,7 @@ export default function PracticePage({
                         <label className="block text-sm font-medium mb-2">AIに反論</label>
                         <ChatInterface
                             sessionId={id}
+                            slideUrl={slideUrl ?? undefined}
                             onUserMessage={handleUserMessage}
                             onAssistantChunk={handleAssistantChunk}
                             onAssistantDone={handleAssistantDone}

--- a/src/components/practice/ChatInterface.tsx
+++ b/src/components/practice/ChatInterface.tsx
@@ -12,6 +12,7 @@ export interface Message {
 interface ChatInterfaceProps {
     sessionId: string;
     persona?: string;
+    slideUrl?: string;
     onUserMessage?: (text: string) => void;
     onAssistantChunk?: (chunk: string) => void;
     onAssistantDone?: (fullText: string, emotion?: string) => void;
@@ -20,6 +21,7 @@ interface ChatInterfaceProps {
 export default function ChatInterface({
     sessionId,
     persona,
+    slideUrl,
     onUserMessage,
     onAssistantChunk,
     onAssistantDone,
@@ -46,7 +48,7 @@ export default function ChatInterface({
                 const res = await fetch("/api/chat", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ sessionId, message: trimmed, persona }),
+                    body: JSON.stringify({ sessionId, message: trimmed, persona, slideUrl }),
                     signal: controller.signal,
                 });
 
@@ -88,7 +90,7 @@ export default function ChatInterface({
                 setIsLoading(false);
             }
         },
-        [input, isLoading, sessionId, persona, onUserMessage, onAssistantChunk, onAssistantDone]
+        [input, isLoading, sessionId, persona, slideUrl, onUserMessage, onAssistantChunk, onAssistantDone]
     );
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/practice/SlideViewer.tsx
+++ b/src/components/practice/SlideViewer.tsx
@@ -19,12 +19,15 @@ interface SlideViewerProps {
     onPageChange?: (newPage: number) => void;
     /** PDF の総ページ数が確定したときに呼ばれるコールバック */
     onNumPagesReady?: (totalPages: number) => void;
+    /** PDF の公開 URL が確定したときに呼ばれるコールバック */
+    onPdfUrlReady?: (url: string) => void;
 }
 
 export default function SlideViewer({
     sessionId = "default",
     onPageChange,
     onNumPagesReady,
+    onPdfUrlReady,
 }: SlideViewerProps) {
     const [pdfUrl, setPdfUrl] = useState<string | null>(null);
     const [pdfFileName, setPdfFileName] = useState<string | null>(null);
@@ -43,11 +46,12 @@ export default function SlideViewer({
                 const { url, name } = JSON.parse(stored);
                 setPdfUrl(url);
                 setPdfFileName(name);
+                onPdfUrlReady?.(url);
             } catch {
                 localStorage.removeItem(storageKey(sessionId));
             }
         }
-    }, [sessionId]);
+    }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // ファイルを選択・ドロップしたときの共通処理
     const handleFile = useCallback(
@@ -73,6 +77,7 @@ export default function SlideViewer({
                     storageKey(sessionId),
                     JSON.stringify({ url: publicUrl, name: file.name })
                 );
+                onPdfUrlReady?.(publicUrl);
             } catch (err) {
                 console.warn("Supabase upload failed:", err);
                 // アップロード失敗はプレビュー表示には影響させない


### PR DESCRIPTION
# 概要
アップロードされたスライドPDFのURLをGemini APIに渡し、AIがスライドの内容を踏まえた反論・コメントを生成できるようにした。

## app/api/chat/route.ts
- リクエストボディから slideUrl?: string を受け取るように変更。
- slideUrl がある場合、サーバー側でPDFを fetch して base64 に変換し、inlineData として Gemini の contents に追加。
　　・ fileData.fileUri は Gemini Files API 専用URIにしか対応しないため、任意の公開URL（Supabase等）には inlineData　　　　（base64）を使用。
- systemInstruction に「スライドの内容を踏まえて反論・コメントしてください」を追記。

## src/components/practice/ChatInterface.tsx
- slideUrl?: string prop を追加。
- /api/chat のリクエストボディに slideUrl を含める。

## src/components/practice/SlideViewer.tsx
- onPdfUrlReady?: (url: string) => void prop を追加。
- アップロード成功時・ページリロード時の localStorage 復元時の両方でコールバックを呼ぶ。

## app/practice/[id]/page.tsx
- slideUrl state を追加。
- SlideViewer の onPdfUrlReady={setSlideUrl} でアップロード後もリアルタイムに slideUrl を更新。
- ChatInterface と handleFeedbackReady（後続 #12 対応）に slideUrl を渡す。

## 動作確認
- スライドPDFをアップロードしてからチャットを送信すると、AIがスライドの内容に言及した返答を生成することを確認。
- スライド未アップロード時は従来通りテキストのみで動作することを確認。