### PR TITLE
27-AIの出力する感情の限定

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -11,10 +11,21 @@ export interface PersonaData {
 }
 
 /** ペルソナ情報からシステムプロンプトを組み立てる */
+const ALLOWED_EMOTIONS = ['neutral', 'thinking', 'satisfied', 'skeptical', 'angry', 'impressed'] as const;
+type Emotion = typeof ALLOWED_EMOTIONS[number];
+
+function normalizeEmotion(raw: string): Emotion {
+    const lower = raw.toLowerCase().trim();
+    return (ALLOWED_EMOTIONS as readonly string[]).includes(lower)
+        ? (lower as Emotion)
+        : 'neutral';
+}
+
 function buildSystemPrompt(personaData?: PersonaData): string {
     if (!personaData || !personaData.name) {
         return [
-            '返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください（例: emotion: 興味深い）。',
+            '返答の最後に必ず、あなたの感情を "emotion: <感情名>" の形式で1行追加してください。',
+            '感情は必ず次の6つのいずれかを使用してください: neutral / thinking / satisfied / skeptical / angry / impressed',
         ].join('\n');
     }
 
@@ -97,7 +108,7 @@ export async function POST(req: Request) {
                     }
 
                     const emotionMatch = fullText.match(/emotion:\s*(.+)/);
-                    const emotion = emotionMatch ? emotionMatch[1].trim() : 'neutral';
+                    const emotion = emotionMatch ? normalizeEmotion(emotionMatch[1]) : 'neutral';
                     controller.enqueue(encoder.encode(`data: ${JSON.stringify({ emotion })}\n\n`));
 
                     // AIの応答をDBに保存


### PR DESCRIPTION
# route.tsの変更点
- 感情の定義: AIが使用できる感情を neutral, thinking, satisfied, skeptical, angry, impressed の6種類に制限しました。
正規化ロジックの追加: 

- normalizeEmotion 関数を導入し、AIが指定外の感情（例: "happy" や日本語など）を返した場合に自動で neutral へ変換・抽出するようにしました。
- 指示の明確化: システムプロンプトを修正し、AIに対して「感情はこの6つの英単語からのみ選ぶこと」という指示を強化しました。
- 抽出処理の統合: レスポンスから感情を抽出する際、必ず正規化ロジックを通してからDB保存・フロントエンド返却を行うように修正しました。

