### PR TITLE
36-AI出力emotion:の削除

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -208,11 +208,7 @@ export default function PracticePage({
                                                 }`}
                                         >
                                             {msg.text}
-                                            {msg.emotion && (
-                                                <p className="mt-1 text-xs text-gray-500 italic">
-                                                    😊 {msg.emotion}
-                                                </p>
-                                            )}
+
                                         </div>
                                     </div>
                                 ))}

--- a/src/components/practice/ChatInterface.tsx
+++ b/src/components/practice/ChatInterface.tsx
@@ -82,7 +82,9 @@ export default function ChatInterface({
                         } catch { /* ignore */ }
                     }
                 }
-                onAssistantDone?.(accumulated, emotion);
+                // emotion: xxx 行を表示テキストから除去する
+                const cleanedText = accumulated.replace(/\n?emotion:\s*.+$/m, '').trimEnd();
+                onAssistantDone?.(cleanedText, emotion);
             } catch (err: unknown) {
                 if (err instanceof Error && err.name !== "AbortError") {
                     console.error("Chat API エラー:", err);


### PR DESCRIPTION
# Chatinterface.tsxの変更内容
- 感情行の除去: ストリーム受信完了時に、accumulated（全テキスト）から正規表現で emotion: xxx の行を削除した cleanedText を生成し、onAssistantDone に渡すようにした。感情値自体は別途 emotion 変数として引き続き渡している。

# page.tsxの変更内容
- 感情テキスト表示の削除: チャット履歴の各メッセージ（吹き出し）内に表示されていた「😊 neutral」といった感情アイコンと英単語の表示処理を削除しました。
- 表示のみの変更: UI（見た目）の表示を消しただけで、感情のデータ自体は引き続き内部で保持されています。
- アバター連携の維持: 感情データは引き続き CharacterAvatar コンポーネントに渡されるため、AIの感情に合わせたアバターの表情やアニメーションの変化は、これまで通り機能します。