### PR TITLE
34-入力操作の修正

### DIFF
--- a/src/components/practice/ChatInterface.tsx
+++ b/src/components/practice/ChatInterface.tsx
@@ -120,31 +120,25 @@ export default function ChatInterface({
         );
     }
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            handleSubmit(e as unknown as React.FormEvent);
-        }
-    };
 
     return (
-        <form onSubmit={handleSubmit} className="flex gap-2">
+        <div className="flex gap-2">
             <input
                 type="text"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleKeyDown}
                 placeholder="反論を入力..."
                 disabled={isLoading}
                 className="flex-1 border border-border rounded-full px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
             />
             <button
-                type="submit"
+                type="button"
+                onClick={handleSubmit as unknown as React.MouseEventHandler}
                 disabled={isLoading || !input.trim()}
                 className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-full hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
                 {isLoading ? "送信中" : "送信"}
             </button>
-        </form>
+        </div>
     );
 }


### PR DESCRIPTION
## form タグをdiv に変更
- ブラウザの標準仕様では、フォーム内の入力欄でEnterを押すと自動的に送信（Submit）されます。これを防ぐためにフォーム自体を廃止しました。
## handleKeyDown 関数の削除
- プログラム側でEnterキー入力を検知して送信を実行していた処理（onKeyDown）を削除しました。
## 「送信」ボタンの動作変更
- ボタンのタイプを submit から button に変更し、ボタンがクリックされた時のみ handleSubmit が実行されるように紐付けました。