### PR TITLE
55-画面比率に応じたアバター画像の調整

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function PracticePage({
                 </div>
 
                 {/* 右カラム: AIコメント + 設定 */}
-                <div className="w-[420px] flex flex-col bg-white">
+                <div className="w-[260px] sm:w-[300px] md:w-[360px] lg:w-[420px] flex flex-col bg-white">
                     {/* 右カラム: アバター表示 */}
                     <div className="border-b border-border bg-gray-50/30">
                         <CharacterAvatar emotion={currentEmotion} />

--- a/src/components/practice/CharacterAvatar.tsx
+++ b/src/components/practice/CharacterAvatar.tsx
@@ -44,7 +44,7 @@ export default function CharacterAvatar({ emotion = 'neutral' }: CharacterAvatar
 
   return (
     <div className={`w-full flex justify-center p-4 transition-colors duration-300 ${config.bg}`}>
-      <div className={`relative w-full h-48 md:h-60 transition-all duration-300 ${config.animation}`}>
+      <div className={`relative w-full h-20 sm:h-28 md:h-36 lg:h-44 xl:h-52 max-h-[22vh] transition-all duration-300 ${config.animation}`}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={avatarUrl}


### PR DESCRIPTION
# src\components\practice\CharacterAvatar.tsxの変更点
## レスポンシブな高さ設定
- 以前は h-48（192px）や h-60（240px）といった固定的な高さでしたが、画面幅（sm, md, lg, xl）に合わせて、80pxから208pxの間で段階的に変化するように変更しました。
##  最大高さの制限 (max-h)
- max-h-[22vh] を追加しました。これにより、どんなに画面の横幅が広くても、画像が画面全体の高さの22%を超えないようになり、チャット欄が画像で埋まるのを防いでいます。
## 表示比率の維持
- 画像が歪まないよう object-contain などを維持しつつ、コンテナのサイズを柔軟にすることで、レスポンシブ対応を実現しました。


# app\practice\[id]\page.tsxの変更点
## 固定幅から可変幅への変更
- 以前は w-[420px] という固定された幅でしたが、画面サイズ（sm, md, lg）に応じて 260pxから420pxの間で段階的に広がるように設定しました。
## レイアウトの最適化
- 幅が柔軟になったことで、画面が小さい場合に右カラムが場所を取りすぎるのを防ぎ、左側のスライド表示や録音エリアのスペースをより広く確保できるようになりました。