### PR TITLE
チュートリアルの表示

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -17,6 +17,7 @@ import PersonaConfig from "@/src/components/setup/PersonaConfig";
 import PersonaSelector from "@/src/components/setup/PersonaSelector";
 import KnowledgeUpload from "@/src/components/setup/KnowledgeUpload";
 import CharacterAvatar, { EmotionType } from "@/src/components/practice/CharacterAvatar";
+import TutorialOverlay from "@/src/components/practice/TutorialOverlay";
 import { supabase } from "@/src/lib/supabase";
 import Logo from "@/src/components/common/Logo";
 import type { PersonaData } from "@/app/api/chat/route";
@@ -100,6 +101,9 @@ export default function PracticePage({
     const [isFeedbackLoading, setIsFeedbackLoading] = useState(false);
     const [feedbackError, setFeedbackError] = useState<string | null>(null);
 
+    // チュートリアル（新規セッション＝メッセージ履歴が空の場合のみ表示）
+    const [isTutorialOpen, setIsTutorialOpen] = useState(false);
+
     /** sessions.persona_id → personas テーブルからペルソナ情報を取得 */
     const loadPersona = useCallback(async () => {
         const { data: sessionData } = await supabase
@@ -136,7 +140,15 @@ export default function PracticePage({
                 const res = await fetch(`/api/chat_logs/${id}`);
                 if (res.ok) {
                     const { messages: history } = await res.json();
-                    setMessages(history ?? []);
+                    const loaded: Message[] = history ?? [];
+                    setMessages(loaded);
+
+                    // 履歴が空 = 新規セッション → チュートリアルを表示（1度のみ）
+                    const tutorialKey = `tutorial_shown_${id}`;
+                    if (loaded.length === 0 && !localStorage.getItem(tutorialKey)) {
+                        setIsTutorialOpen(true);
+                        localStorage.setItem(tutorialKey, "1");
+                    }
                 }
             } catch (err) {
                 console.error("履歴の取得に失敗しました:", err);
@@ -183,6 +195,10 @@ export default function PracticePage({
 
     return (
         <div className="h-screen flex flex-col">
+            {/* チュートリアル（セッション初回のみ） */}
+            {isTutorialOpen && (
+                <TutorialOverlay onClose={() => setIsTutorialOpen(false)} />
+            )}
             {/* ヘッダー */}
             <header className="bg-white border-b border-border px-4 py-2 flex items-center justify-between">
                 <Link href="/" className="text-sm text-foreground-muted hover:text-foreground">

--- a/src/components/practice/TutorialOverlay.tsx
+++ b/src/components/practice/TutorialOverlay.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+interface TutorialOverlayProps {
+    onClose: () => void;
+}
+
+export default function TutorialOverlay({ onClose }: TutorialOverlayProps) {
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+            onClick={onClose}
+        >
+            <div
+                className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 flex flex-col gap-5"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* ヘッダー */}
+                <div className="flex items-center gap-2">
+                    <span className="text-2xl">👋</span>
+                    <h2 className="text-lg font-bold text-gray-800">Logeachへようこそ！</h2>
+                </div>
+
+                {/* AIの設定 */}
+                <section>
+                    <h3 className="text-sm font-semibold text-blue-600 mb-2">⚙️ AIの設定</h3>
+                    <ol className="text-sm text-gray-700 space-y-1.5 list-none">
+                        <li>
+                            <span className="font-medium">1.</span>【AIの人物像をカスタマイズ】からAIの性格や専門分野を設定
+                        </li>
+                        <li>
+                            <span className="font-medium">2.</span>【前提知識をアップロード】からAIに学ばせたい資料をアップロード
+                        </li>
+                        <li>
+                            <span className="font-medium">3.</span>【ペルソナを選択】からプリセットのキャラクターを選ぶことも可能
+                        </li>
+                    </ol>
+                </section>
+
+                <hr className="border-gray-100" />
+
+                {/* 使い方 */}
+                <section>
+                    <h3 className="text-sm font-semibold text-green-600 mb-2">🎤 Logeachの使い方</h3>
+                    <ol className="text-sm text-gray-700 space-y-1.5 list-none">
+                        <li>
+                            <span className="font-medium">1.</span>【スライド（PDF）をアップロード】からプレゼン資料をアップロード
+                        </li>
+                        <li>
+                            <span className="font-medium">2.</span>【録音開始】でスライドに合わせてプレゼンを練習
+                        </li>
+                        <li>
+                            <span className="font-medium">3.</span>【録音終了】後、AIにフィードバックをもらう
+                        </li>
+                        <li>
+                            <span className="font-medium">4.</span>【AIに反論】欄からAIと議論して理解を深める
+                        </li>
+                    </ol>
+                </section>
+
+                <p className="text-xs text-gray-400 text-center">← / → キーでスライドを切り替えられます</p>
+
+                {/* 閉じるボタン */}
+                <button
+                    onClick={onClose}
+                    className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-xl transition-colors duration-150"
+                >
+                    はじめる！
+                </button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
# src\components\practice\TutorialOverlay.tsx
- AIの設定手順（人物像カスタマイズ・前提知識・ペルソナ選択）
- Logeachの使い方（PDF→録音→フィードバック→反論）
- キーボード操作のヒント
- 「はじめる！」ボタン or 背景クリックで閉じる
- 背景をぼかした（backdrop-blur）半透明のオーバーレイで、中央に説明カードを表示します。
- 「はじめる！」ボタンを押すことで閉じられ、そのセッションでは二度と表示されないように page.tsx 側で制御されています。


# app\practice\[id]\page.tsxの変更内容
- localStorage のキー tutorial_shown_{セッションID} でセッションごとに初回のみ表示を管理
- 2回目以降は表示されません（一度閉じると再表示しない）
- 履歴APIが完了し、メッセージが0件 → 新規セッションと判断 → チュートリアルを表示
- メッセージが1件以上 → 再開セッションと判断 → チュートリアルを表示しない
- localStorageで追加管理しているので、新規セッションを閉じて再開した場合も2回目は表示されません