### PR TITLE
感情別アバター画像のユーザーカスタムアップロード

### DIFF
--- a/app/practice/[id]/page.tsx
+++ b/app/practice/[id]/page.tsx
@@ -248,7 +248,7 @@ export default function PracticePage({
                 <div className="w-[260px] sm:w-[300px] md:w-[360px] lg:w-[420px] flex flex-col bg-white">
                     {/* 右カラム: アバター表示 */}
                     <div className="border-b border-border bg-gray-50/30">
-                        <CharacterAvatar emotion={currentEmotion} />
+                        <CharacterAvatar emotion={currentEmotion} sessionId={id} />
                     </div>
                     {/* AIコメント表示エリア（スクロール） */}
                     <div className="flex-1 overflow-y-auto p-4 space-y-3">

--- a/src/components/practice/CharacterAvatar.tsx
+++ b/src/components/practice/CharacterAvatar.tsx
@@ -1,13 +1,22 @@
+import { useState, useEffect } from 'react';
+import { getAvatarUrl } from '@/src/lib/storage';
 import { supabase } from '@/src/lib/supabase';
 
 export type EmotionType = 'neutral' | 'thinking' | 'satisfied' | 'skeptical' | 'angry' | 'impressed';
 
 interface CharacterAvatarProps {
   emotion?: string; // 日本語が混ざる可能性があるので string で受け取る
+  sessionId?: string; // カスタムアバターを使う場合に指定
 }
 
-export default function CharacterAvatar({ emotion = 'neutral' }: CharacterAvatarProps) {
-  
+// デフォルトアバターURL（Supabase Storage の default/ フォルダ）を返す
+function getDefaultAvatarUrl(em: EmotionType): string {
+  const { data } = supabase.storage.from('avatars').getPublicUrl(`default/${em}.png`);
+  return data?.publicUrl || `/characters/${em}.png`;
+}
+
+export default function CharacterAvatar({ emotion = 'neutral', sessionId }: CharacterAvatarProps) {
+
   // 1. 日本語などをシステム用の英語名に変換する辞書
   const emotionMap: Record<string, EmotionType> = {
     "neutral": "neutral",
@@ -38,21 +47,28 @@ export default function CharacterAvatar({ emotion = 'neutral' }: CharacterAvatar
 
   const config = emotionConfigs[safeEmotion];
 
-  // 4. SupabaseのPublic URLを取得する
-  const { data } = supabase.storage.from('avatars').getPublicUrl(`default/${safeEmotion}.png`);
-  const avatarUrl = data?.publicUrl || `/characters/${safeEmotion}.png`;
+  // 4. 表示する画像URL（カスタムを優先し、失敗時にデフォルトへフォールバック）
+  const [src, setSrc] = useState<string>(() =>
+    sessionId ? getAvatarUrl(sessionId, safeEmotion) : getDefaultAvatarUrl(safeEmotion)
+  );
+
+  // emotion または sessionId が変化したら src をリセット
+  // （レンダリング中に setState するアンチパターンを避けるために useEffect を使う）
+  useEffect(() => {
+    setSrc(sessionId ? getAvatarUrl(sessionId, safeEmotion) : getDefaultAvatarUrl(safeEmotion));
+  }, [safeEmotion, sessionId]);
 
   return (
     <div className={`w-full flex justify-center p-4 transition-colors duration-300 ${config.bg}`}>
       <div className={`relative w-full h-20 sm:h-28 md:h-36 lg:h-44 xl:h-52 max-h-[22vh] transition-all duration-300 ${config.animation}`}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={avatarUrl}
+          src={src}
           alt={`Character emotion: ${safeEmotion}`}
           className="object-contain w-full h-full"
-          onError={(e) => {
-              // URLが間違っていた場合やバケットが存在しない場合はローカル画像にフォールバック
-              e.currentTarget.src = `/characters/${safeEmotion}.png`;
+          onError={() => {
+            // カスタム画像が存在しない（404 など）場合はデフォルト画像にフォールバック
+            setSrc(getDefaultAvatarUrl(safeEmotion));
           }}
         />
       </div>

--- a/src/components/setup/PersonaConfig.tsx
+++ b/src/components/setup/PersonaConfig.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/src/lib/supabase";
 import { useAuth } from "@/src/components/auth/AuthProvider";
+import { uploadAvatarImage, getAvatarUrl } from "@/src/lib/storage";
+import type { EmotionType } from "@/src/components/practice/CharacterAvatar";
 
 /**
  * PersonaConfig コンポーネント
@@ -21,6 +23,34 @@ export default function PersonaConfig({
     const [landmines, setLandmines] = useState("");
     const [background, setBackground] = useState("");
     const [isSaving, setIsSaving] = useState(false);
+
+    // アバターアップロード用ステート
+    const EMOTIONS: EmotionType[] = ["neutral", "thinking", "satisfied", "skeptical", "angry", "impressed"];
+    const EMOTION_LABELS: Record<EmotionType, string> = {
+        neutral: "普通",
+        thinking: "考え中",
+        satisfied: "満足",
+        skeptical: "懐疑的",
+        angry: "怒り",
+        impressed: "感銘",
+    };
+    const [avatarUploading, setAvatarUploading] = useState<Record<EmotionType, boolean>>({
+        neutral: false, thinking: false, satisfied: false,
+        skeptical: false, angry: false, impressed: false,
+    });
+    // 各感情のサムネイルURL（アップロード後に更新）
+    const [avatarThumbs, setAvatarThumbs] = useState<Record<EmotionType, string>>(() => {
+        const init = {} as Record<EmotionType, string>;
+        for (const em of ["neutral", "thinking", "satisfied", "skeptical", "angry", "impressed"] as EmotionType[]) {
+            init[em] = getAvatarUrl(sessionId, em);
+        }
+        return init;
+    });
+    // サムネイルが実際に存在するか（onError でフォールバック）
+    const [avatarExists, setAvatarExists] = useState<Record<EmotionType, boolean>>({
+        neutral: false, thinking: false, satisfied: false,
+        skeptical: false, angry: false, impressed: false,
+    });
 
     // 初期化時に既存のデータを取得する
     useEffect(() => {
@@ -103,6 +133,21 @@ export default function PersonaConfig({
         }
     };
 
+    const handleAvatarUpload = async (emotion: EmotionType, file: File) => {
+        setAvatarUploading((prev) => ({ ...prev, [emotion]: true }));
+        try {
+            const url = await uploadAvatarImage(file, sessionId, emotion);
+            // キャッシュバスターを付与してサムネイルを更新
+            setAvatarThumbs((prev) => ({ ...prev, [emotion]: `${url}?t=${Date.now()}` }));
+            setAvatarExists((prev) => ({ ...prev, [emotion]: true }));
+        } catch (err: any) {
+            console.error("アバターアップロードエラー:", err);
+            alert(`アップロードに失敗しました: ${err.message || "不明なエラー"}`);
+        } finally {
+            setAvatarUploading((prev) => ({ ...prev, [emotion]: false }));
+        }
+    };
+
     return (
         <div className="space-y-6">
             <form onSubmit={handleSave} className="space-y-4">
@@ -152,6 +197,62 @@ export default function PersonaConfig({
                     {isSaving ? "保存中..." : "保存する"}
                 </button>
             </form>
+
+            {/* アバター画像アップロードセクション */}
+            <div className="border-t border-border pt-4">
+                <p className="text-sm font-medium mb-3">感情ごとのアバター画像</p>
+                <p className="text-xs text-muted-foreground mb-4">
+                    各感情に対応する画像をアップロードすると、デフォルト画像の代わりに使用されます（PNG・JPG推奨）。
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                    {EMOTIONS.map((emotion) => (
+                        <div key={emotion} className="flex flex-col items-center gap-2 p-3 border rounded-lg bg-muted/20">
+                            {/* サムネイル */}
+                            <div className="w-16 h-16 rounded-md overflow-hidden bg-muted flex items-center justify-center shrink-0">
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                    src={avatarThumbs[emotion]}
+                                    alt={`${emotion} avatar`}
+                                    className="w-full h-full object-cover"
+                                    onLoad={() =>
+                                        setAvatarExists((prev) => ({ ...prev, [emotion]: true }))
+                                    }
+                                    onError={(e) => {
+                                        setAvatarExists((prev) => ({ ...prev, [emotion]: false }));
+                                        (e.currentTarget as HTMLImageElement).style.display = "none";
+                                    }}
+                                />
+                                {!avatarExists[emotion] && (
+                                    <span className="text-2xl text-muted-foreground select-none">🖼️</span>
+                                )}
+                            </div>
+
+                            {/* 感情ラベル */}
+                            <span className="text-xs font-medium text-center leading-tight">
+                                {EMOTION_LABELS[emotion]}
+                                <br />
+                                <span className="text-muted-foreground font-normal">({emotion})</span>
+                            </span>
+
+                            {/* アップロードボタン */}
+                            <label className={`w-full text-center cursor-pointer text-xs px-2 py-1.5 rounded-md border border-border transition-colors ${avatarUploading[emotion] ? "opacity-50 cursor-not-allowed bg-muted" : "hover:bg-muted"}`}>
+                                {avatarUploading[emotion] ? "アップロード中..." : avatarExists[emotion] ? "変更" : "選択"}
+                                <input
+                                    type="file"
+                                    accept="image/*"
+                                    className="hidden"
+                                    disabled={avatarUploading[emotion]}
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) handleAvatarUpload(emotion, file);
+                                        e.target.value = "";
+                                    }}
+                                />
+                            </label>
+                        </div>
+                    ))}
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -25,3 +25,40 @@ export async function uploadSlidePdf(
     const { data } = supabase.storage.from("slides").getPublicUrl(path);
     return data.publicUrl;
 }
+
+/**
+ * Supabase Storage の "avatars" バケットに感情別アバター画像をアップロードし、
+ * 公開 URL を返す。
+ *
+ * @param file - アップロードする画像ファイル
+ * @param sessionId - 練習セッション ID
+ * @param emotion - 感情名（neutral / thinking / satisfied / skeptical / angry / impressed）
+ * @returns 公開 URL（string）
+ * @throws アップロード失敗時に Error をスロー
+ */
+export async function uploadAvatarImage(
+    file: File,
+    sessionId: string,
+    emotion: string
+): Promise<string> {
+    const path = `${sessionId}/${emotion}.png`;
+    const { error } = await supabase.storage
+        .from("avatars")
+        .upload(path, file, { upsert: true });
+    if (error) throw new Error(error.message);
+    const { data } = supabase.storage.from("avatars").getPublicUrl(path);
+    return data.publicUrl;
+}
+
+/**
+ * ユーザーがアップロードしたカスタムアバター画像の公開 URL を返す。
+ * カスタム画像が存在しない場合のフォールバックは呼び出し側で制御する。
+ *
+ * @param sessionId - 練習セッション ID
+ * @param emotion - 感情名
+ * @returns 公開 URL（string）
+ */
+export function getAvatarUrl(sessionId: string, emotion: string): string {
+    const base = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/avatars`;
+    return `${base}/${sessionId}/${emotion}.png`;
+}


### PR DESCRIPTION
# page.tsxの変更内容
## CharacterAvatarへの sessionId の受け渡し
- CharacterAvata コンポーネントを表示している箇所（右カラム上部）で、プロップとして sessionId={id} を追加しました
## カスタム画像の表示連携:
- これにより、アバター側で「そのセッション用にアップロードされた画像があるか」を判別できるようになり、アップロード済みのカスタム画像が優先的に表示されるようになりました。

# PersonaConfig.tsxの変更内容
## アバターアップロード用UIの追加:
- コンポーネントの下部に、6種類の感情（普通、考え中、満足、懐疑的、怒り、感銘）ごとに画像をアップロードできる専用セクションを追加しました。
## サムネイル表示機能:
- 各感情に対応するアップロード済みの画像をサムネイルとして表示するようにしました。画像がない場合はアイコン（🖼️）が表示されます。
## アップロード処理の実装:
- handleAvatarUpload関数を追加し、ファイル選択時に Supabase Storage へ自動で画像をアップロードするロジックを実装しました。
## 即時反映（キャッシュ対策）:
- 画像が上書きされた際にブラウザのキャッシュで古い画像が表示されないよう、アップロード成功時にクエリパラメータ（?t=...）を付与してサムネイルが即座に更新されるようにしました。
## インポートの追加:
- Storage 操作用の自作関数（uploadAvatarImage, getAvatarUrl）をインポートして連携させました。


# CharacterAvatar.tsxの変更内容
## sessionId プロップの追加:
- セッションごとにアップロードされた画像を識別できるよう、sessionId を受け取るように変更しました。
## 表示優先順位のロジック実装:
- ユーザーがアップロードした「カスタム画像」がある場合はそれを優先し、存在しない場合は「デフォルト画像」を表示するという優先順位を実装しました。
## 自動フォールバック機能 (onError):
- ユーザーが画像をアップロードしていない場合（カスタム画像のURLが 404 エラーになる場合）、自動的に default/ の画像に切り替えるフォールバック処理を追加しました。
## React 状態管理の最適化 (useEffect):
- レンダリング中に直接状態を更新するバグを修正し、useEffect を使って「感情の変化」や「セッションの切り替え」に合わせて画像を正しく切り替えるように改善しました。
## デフォルト画像取得の共通化:
- Supabase Storage の default/ フォルダから公開URLを取得する getDefaultAvatarUrl関数を定義しました。


# storage.tsの変更内容
## uploadAvatarImage関数の追加:
- avatars バケットに対して、{sessionId}/{emotion}.png というパスで画像をアップロードする機能を実装しました。
- 同じ感情の画像が既に存在する場合、上書き（upsert: true）するように設定されています。

## getAvatarUrl関数の追加:
- 指定されたセッション ID と感情名から、カスタムアバター画像の公開 URL を生成して返す関数を実装しました。
## 既存機能の保持:
- 元々存在していたスライド PDF アップロード用関数（uploadSlidePdf）は、一切変更せずにそのまま維持しています。
