### PR TITLE
Configure Cloudflare Pages to use OpenNext build output and add assoc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "pages:build": "npx @opennextjs/cloudflare@latest build",
+    "pages:deploy": "npx wrangler pages deploy .open-next/cloudflare"
   },
   "dependencies": {
     "@google/genai": "^1.44.0",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,5 +2,5 @@
 name = "logeach"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
-pages_build_output_dir = ".vercel/output"
+pages_build_output_dir = ".open-next/cloudflare"
 


### PR DESCRIPTION
package.json: 新しいビルドコマンド npx @opennextjs/cloudflare@latest build を pages:build スクリプトとして追加しました。
wrangler.toml: ビルド出力ディレクトリを .open-next/cloudflare に変更しました。